### PR TITLE
fix: Apply range bounds to both sunrise and sunset times

### DIFF
--- a/suntime/suntime.py
+++ b/suntime/suntime.py
@@ -137,8 +137,7 @@ class Sun:
 
         # 7c. rounding and impose range bounds
         UT = round(UT, 2)
-        if is_rise_time:
-            UT = self._force_range(UT, 24)
+        UT = self._force_range(UT, 24)  # Apply to both sunrise and sunset
 
         # 8. return timedelta
         return timedelta(hours=UT)


### PR DESCRIPTION
For Sunset: If the calculated UT value is negative or >= 24 hours (which can happen with certain timezone offsets), it was not normalized.

```python
#!/usr/bin/env python3
"""
Test script to demonstrate the bug in suntime.py library.

Bug: The _force_range() normalization is only applied to sunrise times,
not sunset times, causing sunset to return incorrect dates when the
calculated UT value falls outside [0, 24) range.
"""

from suntime import Sun
from datetime import datetime
from zoneinfo import ZoneInfo

print("=" * 80)
print("suntime.py Bug Demonstration")
print("=" * 80)
print()

LATITUDE = 49.5
LONGITUDE = 11.500000
LOCAL_TIMEZONE = ZoneInfo("Europe/Berlin")

sun = Sun(LATITUDE, LONGITUDE)

# Test various dates
test_dates = [
    datetime(2025, 12, 25),  # Winter
    datetime(2025, 6, 21),   # Summer solstice
    datetime(2025, 3, 20),   # Spring equinox
    datetime(2025, 1, 1),    # New year
]

print(f"Location: {LATITUDE:.6f}°N, {LONGITUDE:.6f}°E")
print(f"Timezone: {LOCAL_TIMEZONE}")
print()

for test_date in test_dates:
    print("-" * 80)
    print(f"Testing date: {test_date.date()}")
    print("-" * 80)

    # Get sunrise - should work correctly
    sunrise = sun.get_sunrise_time(test_date, time_zone=LOCAL_TIMEZONE)
    print(f"\nSunrise:")
    print(f"  Returned datetime: {sunrise}")
    print(f"  Date component:    {sunrise.date()}")
    print(f"  Time component:    {sunrise.time()}")
    print(f"  ✓ Date matches input: {sunrise.date() == test_date.date()}")

    # Get sunset - BUG: may return wrong date
    sunset = sun.get_sunset_time(test_date, time_zone=LOCAL_TIMEZONE)
    print(f"\nSunset:")
    print(f"  Returned datetime: {sunset}")
    print(f"  Date component:    {sunset.date()}")
    print(f"  Time component:    {sunset.time()}")

    date_matches = sunset.date() == test_date.date()
    if date_matches:
        print(f"  ✓ Date matches input: True")
    else:
        print(f"  ✗ BUG DETECTED! Date doesn't match input!")
        print(f"    Expected: {test_date.date()}")
        print(f"    Got:      {sunset.date()}")
        print(f"    Difference: {(sunset.date() - test_date.date()).days} day(s)")
```

(Partial) Output:

```
--------------------------------------------------------------------------------
Testing date: 2025-12-25
--------------------------------------------------------------------------------

Sunrise:
  Returned datetime: 2025-12-25 08:09:36+01:00
  Date component:    2025-12-25
  Time component:    08:09:36
  ✓ Date matches input: True

Sunset:
  Returned datetime: 2025-12-24 16:18:36+01:00
  Date component:    2025-12-24
  Time component:    16:18:36
  ✗ BUG DETECTED! Date doesn't match input!
    Expected: 2025-12-25
    Got:      2025-12-24
    Difference: -1 day(s)

--------------------------------------------------------------------------------
Testing date: 2025-06-21
--------------------------------------------------------------------------------

Sunrise:
  Returned datetime: 2025-06-21 05:07:12+02:00
  Date component:    2025-06-21
  Time component:    05:07:12
  ✓ Date matches input: True

Sunset:
  Returned datetime: 2025-06-20 21:24:00+02:00
  Date component:    2025-06-20
  Time component:    21:24:00
  ✗ BUG DETECTED! Date doesn't match input!
    Expected: 2025-06-21
    Got:      2025-06-20
    Difference: -1 day(s)
```